### PR TITLE
Add demo with a parent and child shadow tree

### DIFF
--- a/public/anchor-shadow-child.css
+++ b/public/anchor-shadow-child.css
@@ -1,0 +1,5 @@
+#child-target-positioning {
+  position: absolute;
+  right: anchor(--shadow-anchor-positioning right, 50px);
+  top: anchor(--shadow-anchor-positioning bottom);
+}

--- a/public/anchor-shadow-child.css
+++ b/public/anchor-shadow-child.css
@@ -1,5 +1,5 @@
 #child-target-positioning {
   position: absolute;
-  right: anchor(--shadow-anchor-positioning right, 50px);
+  right: anchor(--shadow-anchor-positioning right);
   top: anchor(--shadow-anchor-positioning bottom);
 }

--- a/public/anchor-shadow-parent.css
+++ b/public/anchor-shadow-parent.css
@@ -1,0 +1,4 @@
+#parent-anchor-positioning {
+  anchor-name: --shadow-anchor-positioning;
+}
+

--- a/public/anchor-shadow-parent.css
+++ b/public/anchor-shadow-parent.css
@@ -1,4 +1,3 @@
 #parent-anchor-positioning {
   anchor-name: --shadow-anchor-positioning;
 }
-

--- a/shadow-root.html
+++ b/shadow-root.html
@@ -261,16 +261,17 @@ customElements.define("anchor-web-component", AnchorDemo);
           <template shadowrootmode="open">
             <link rel="stylesheet" href="/demo.css" />
             <link rel="stylesheet" href="/anchor-shadow-parent.css" />
-            <div style="position: relative">
-              <div id="shadow-anchor-positioning" class="anchor">Anchor</div>
+            <div style="position: relative;">
+              <child-component data-polyfillable>
+                <template shadowrootmode="open">
+                  <link rel="stylesheet" href="/demo.css" />
+                  <link rel="stylesheet" href="/anchor-shadow-child.css" />
+                  <div id="child-target-positioning" class="target">Target</div>
+                </template>
+              </child-component>
+
+            <div id="parent-anchor-positioning" class="anchor">Anchor</div>
             </div>
-            <child-component data-polyfillable>
-              <template shadowrootmode="open">
-                <link rel="stylesheet" href="/demo.css" />
-                <link rel="stylesheet" href="/anchor-shadow-child.css" />
-                <div id="shadow-target-positioning" class="target">Target</div>
-              </template>
-            </child-component>
           </template>
         </parent-component>
       </div>

--- a/shadow-root.html
+++ b/shadow-root.html
@@ -37,13 +37,14 @@
 
       if (!SUPPORTS_ANCHOR_POSITIONING) {
         btn.addEventListener('click', () => {
-          document
-            .querySelector('anchor-web-component')
-            .applyPolyfill()
-            .then(() => {
-              btn.innerText = 'Polyfill Applied';
-              btn.setAttribute('disabled', '');
-            });
+          Promise.all(
+            [...document.querySelectorAll('[data-polyfillable]')].map((e) =>
+              e.applyPolyfill(),
+            ),
+          ).then(() => {
+            btn.innerText = 'Polyfill Applied';
+            btn.setAttribute('disabled', '');
+          });
         });
       } else {
         btn.innerText = 'No Polyfill Needed';
@@ -53,13 +54,28 @@
         );
       }
 
-      class AnchorWebComponent extends HTMLElement {
+      class BaseWebComponent extends HTMLElement {
         /* This would typically be run in connectedCallback() */
         applyPolyfill() {
           return polyfill({ root: [this.shadowRoot] });
         }
       }
+
+      class AnchorWebComponent extends BaseWebComponent {}
       customElements.define('anchor-web-component', AnchorWebComponent);
+
+      class ParentComponent extends BaseWebComponent {}
+      customElements.define('parent-component', ParentComponent);
+
+      class ChildComponent extends BaseWebComponent {
+        connectedCallback() {
+          console.log({
+            shadowRoot: this.shadowRoot,
+            host: this.shadowRoot.host.parentNode.host.parentNode.parentNode,
+          });
+        }
+      }
+      customElements.define('child-component', ChildComponent);
     </script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <script src="https://unpkg.com/prismjs@v1.x/components/prism-core.min.js"></script>
@@ -182,7 +198,7 @@
         Works if anchor and target are both inside the same shadow root
       </h2>
       <div class="demo-elements">
-        <anchor-web-component>
+        <anchor-web-component data-polyfillable>
           <template shadowrootmode="open">
             <link rel="stylesheet" href="/demo.css" />
             <link rel="stylesheet" href="/anchor-shadow-root.css" />
@@ -234,6 +250,30 @@ class AnchorDemo extends HTMLElement {
 customElements.define("anchor-web-component", AnchorDemo);
 &lt;/script&gt;
 </code></pre>
+    </section>
+    <section id="nested-shadow-roots" class="demo-item">
+      <h2>
+        <a href="#nested-shadow-roots" aria-hidden="true">🔗</a>
+        Child shadow root can anchor to parent shadow root
+      </h2>
+      <div class="demo-elements">
+        <parent-component data-polyfillable>
+          <template shadowrootmode="open">
+            <link rel="stylesheet" href="/demo.css" />
+            <link rel="stylesheet" href="/anchor-shadow-parent.css" />
+            <div style="position: relative">
+              <div id="shadow-anchor-positioning" class="anchor">Anchor</div>
+            </div>
+            <child-component data-polyfillable>
+              <template shadowrootmode="open">
+                <link rel="stylesheet" href="/demo.css" />
+                <link rel="stylesheet" href="/anchor-shadow-child.css" />
+                <div id="shadow-target-positioning" class="target">Target</div>
+              </template>
+            </child-component>
+          </template>
+        </parent-component>
+      </div>
     </section>
     <section id="sponsor">
       <h2>Sponsor OddBird’s OSS Work</h2>


### PR DESCRIPTION
> Positioned elements in [shadow trees](https://dom.spec.whatwg.org/#concept-shadow-tree) can reference [anchor names](https://drafts.csswg.org/css-anchor-position-1/#anchor-name) defined in “higher” trees.
